### PR TITLE
Do not forward plugin id to sass-loader options

### DIFF
--- a/docusaurus-plugin-sass.js
+++ b/docusaurus-plugin-sass.js
@@ -1,4 +1,4 @@
-module.exports = function(_, options) {
+module.exports = function(_, {id, ...options}) {
   return {
     name: 'docusaurus-plugin-sass',
     configureWebpack(_, isServer, utils) {


### PR DESCRIPTION
I'm a docusaurus maintainer.

Now,the options always contain an id attribute.
This is to support multi-instance plugins where each instance has an id.

It seems this id should not be forwarded to the sass loader instance, see https://github.com/facebook/docusaurus/issues/3361