### PR TITLE
fix: importLoader should point to the sass-loader

### DIFF
--- a/docusaurus-plugin-sass.js
+++ b/docusaurus-plugin-sass.js
@@ -17,7 +17,7 @@ module.exports = function(_, {id, ...options}) {
                       ? `[local]_[hash:base64:4]`
                       : `[local]_[path]`,
                   },
-                  importLoaders: 1,
+                  importLoaders: 2,
                   sourceMap: !isProd,
                   onlyLocals: isServer,
                 }), {


### PR DESCRIPTION
Maybe something changed recently but `getStyleLoaders` returns `css-loader!postcss-loader` now, so an importLoader of 1 causes css-module imports to skip sass-loader