### PR TITLE
Handle "onlyLocals" breaking change

### DIFF
--- a/docusaurus-plugin-sass.js
+++ b/docusaurus-plugin-sass.js
@@ -16,10 +16,10 @@ module.exports = function(_, {id, ...options}) {
                     localIdentName: isProd
                       ? `[local]_[hash:base64:4]`
                       : `[local]_[path]`,
+                    exportOnlyLocals: isServer,
                   },
                   importLoaders: 1,
                   sourceMap: !isProd,
-                  onlyLocals: isServer,
                 }), {
                   loader: 'sass-loader',
                   options: options || {}


### PR DESCRIPTION
Hi, Docusaurus maintainer here.

On our next release, we upgrade a few dependencies to prepare the migration to Webpack 5.

There's a breaking change in the css-loader dependency that affects this plugin.
https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#400-2020-07-25

Without this upgrade, you'll get an error such as

```
ValidationError: Invalid options object. CSS Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'onlyLocals'. These properties are valid:
   object { url?, import?, modules?, sourceMap?, importLoaders?, esModule? }
```

Note this is a breaking change for this plugin, as the new version published may not be compatible anymore with older Docusaurus versions, so you'd rather bump the major version.

As a sidenote, I'm thinking about creating a docusaurus community org with various plugins, would you be interested to move this plugin here so that it's easier for other trusted Docusaurus community members to do the upgrades?