### PR TITLE
Remove `node-sass` dep to allow configuring either `sass` or `node-sass`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Provides support for SASS/SCSS to Docusaurus v2.
 # Installation
 
 ```sh
-yarn add docusaurus-plugin-sass
+yarn add docusaurus-plugin-sass sass
 ```
+
+`sass-loader` requires you to install either [Dart Sass](https://github.com/sass/dart-sass) or [Node Sass](https://github.com/sass/node-sass) on your own (more documentation can be found at [`sass-loader`](https://github.com/webpack-contrib/sass-loader#getting-started)).
 
 # How to use
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Docusaurus plugin to provide support for SASS/SCSS",
   "main": "docusaurus-plugin-sass.js",
   "dependencies": {
-    "node-sass": "^4.13.1",
     "sass-loader": "^10.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
I've also update the README to point user to more information about both compilers, their differences, and use with `sass-loader`.

Fixes #10