### PR TITLE
Fix npm ERESOLVE and EJSONPARSE in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sass-loader": "^10.1.1"
   },
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0",
+    "@docusaurus/core": "^2.0.0-beta",
     "sass": "^1.30.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rlamana/docusaurus-plugin-sass.git",
+    "url": "https://github.com/rlamana/docusaurus-plugin-sass.git"
   },
   "homepage": "https://github.com/rlamana/docusaurus-plugin-sass",
   "keywords": [


### PR DESCRIPTION
Hi, thanks for the work. I love your sass plugin.

This PR resolves two npm errors:

- ERESOLVE
- EJSONPARSE

Commit 92a4884 resolves ERESOLVE.

npm 7 doesn't allow dependency conflict by default, but **the peer dependency of `@docusaurus/core` in package.json has a conflict**. As you know, docusaurus v2 is not officially released yet; it is still in beta release. **Reflecting a high demand(#19) of beta users, I fixed semver from `^2.0.0` to `^2.0.0-beta` to handle the range of `^2.0.0` + prereleases of 2.0.0.** I know the conflict can be ignored locally with `--legacy-peer-deps` option, however, it would be better to patch this since Dependabot can't PR `@docusaurus/core` and the most docusaurus plugins handle beta versions.

Commit d7cb7fd resolves EJSONPARSE.

JSON doesn't allow trailing commas in spec but **there's a single trailing comma in package.json which causes EJSONPARSE.** Fortunately, this bug is not included in v0.2.1 release. It is from the commit 287fcf2, so IMHO this should be fixed before the next release.

This PR closes #19.