### PR TITLE
Docs - mention plugin is compatible with Docusaurus Faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Provides support for SASS/SCSS to Docusaurus v2 and v3.
 
+Note: this plugin is compatible with [Docusaurus Faster](https://github.com/facebook/docusaurus/issues/10556)
+
 # Installation
 
 ```sh


### PR DESCRIPTION
This plugin's `configureWebpack` is compatible out-of-the-box with [Docusaurus Faster](https://github.com/facebook/docusaurus/issues/10556)

Example website using it, running on Faster:
- https://github.com/facebook/react-native-website/pull/4268
- https://github.com/facebook/react-native-website/blob/main/website/package.json